### PR TITLE
Configure Drone CI for automated PDF production.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,20 @@
+kind: pipeline
+name: default
+
+steps:
+  
+- name: build
+  image: pandoc/latex
+  commands:
+  - mkdir -p dist
+  - pandoc README.md -s -o dist/README.pdf
+  - pandoc edge-glossary.md -s -o dist/edge-glossary.pdf
+
+- name: release
+  image: plugins/github-release
+  settings:
+    api_key: 
+      from_secret: GH_RELEASE_TOKEN
+    files: dist/*
+  when:
+    event: tag


### PR DESCRIPTION
#13 sets up CI so that we can automatically produce PDF files from the original files.

This is what got tried earlier in #55 #56 and not merged. This particular piece is just the Drone configuration, there will also be minor changes to the Markdown files due to small differences between Github Markdown and Pandoc Markdown (Pandoc tends to be more strict).